### PR TITLE
feat(xgraceful): configurable health goroutine check

### DIFF
--- a/xgraceful/internal/health.go
+++ b/xgraceful/internal/health.go
@@ -4,9 +4,16 @@ import (
 	"github.com/heptiolabs/healthcheck"
 )
 
-func NewHealth(healthAddr string) Startable {
+// NewHealth builds the health server. goroutineThreshold sets the max goroutine
+// count for the liveness check; a value <= 0 disables that check entirely (the
+// endpoint then only reflects process liveness). This matters for services that
+// legitimately hold many goroutines (e.g. one per long-lived stream), where a
+// fixed count would false-positive and trigger restarts.
+func NewHealth(healthAddr string, goroutineThreshold int) Startable {
 	health := healthcheck.NewHandler()
-	health.AddLivenessCheck("goroutine-threshold", healthcheck.GoroutineCountCheck(100))
+	if goroutineThreshold > 0 {
+		health.AddLivenessCheck("goroutine-threshold", healthcheck.GoroutineCountCheck(goroutineThreshold))
+	}
 
 	return NewStandard(healthAddr, "", "", health)
 }

--- a/xgraceful/serve.go
+++ b/xgraceful/serve.go
@@ -50,12 +50,40 @@ func run(ctx context.Context, s internal.Startable) {
 	<-serverCtx.Done()
 }
 
-func Serve(ctx context.Context, cfg *xservice.ServiceConfig, handler interface{}) {
+// defaultGoroutineThreshold preserves the historical liveness behavior when no
+// option overrides it.
+const defaultGoroutineThreshold = 100
+
+type options struct {
+	goroutineThreshold int
+}
+
+// Option configures Serve.
+type Option func(*options)
+
+// WithGoroutineThreshold sets the max goroutine count for the health server's
+// liveness check. Use a higher value for services that hold many goroutines
+// (e.g. one per long-lived stream). A value <= 0 disables the goroutine check.
+func WithGoroutineThreshold(n int) Option {
+	return func(o *options) { o.goroutineThreshold = n }
+}
+
+// WithoutGoroutineCheck disables the goroutine-count liveness check entirely.
+func WithoutGoroutineCheck() Option {
+	return func(o *options) { o.goroutineThreshold = -1 }
+}
+
+func Serve(ctx context.Context, cfg *xservice.ServiceConfig, handler interface{}, opts ...Option) {
+	o := options{goroutineThreshold: defaultGoroutineThreshold}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	multi := internal.NewMulti(
 		internal.NewZapLog(),
 		internal.NewTracer(ctx, cfg),
 		internal.NewMetrics(ctx, cfg),
-		internal.NewHealth(cfg.HealthAddr),
+		internal.NewHealth(cfg.HealthAddr, o.goroutineThreshold),
 		internal.NewStartable(cfg, handler),
 	)
 	run(ctx, multi)


### PR DESCRIPTION
Makes `xgraceful.Serve`'s liveness goroutine-count check configurable via options (`WithGoroutineThreshold`, `WithoutGoroutineCheck`). Default unchanged (100), so backward compatible. Needed for services like mesh-api that hold many concurrent stream goroutines and would otherwise false-positive into restarts.