### PR TITLE
chore(dependabot): weekly cadence + grouped Go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,25 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Batch all minor/patch Go module bumps into a single PR to avoid the
+      # one-PR-per-dependency pileup. Major bumps are intentionally excluded
+      # so they each get their own PR for individual review.
+      go-modules:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Reduces Dependabot PR noise. Daily + ungrouped config opened one PR per dependency (the recent 5-PR pileup). Now: weekly schedule, all **minor/patch** Go module bumps batched into a single grouped PR (`go-modules`), majors still individual for review, `open-pull-requests-limit: 5`. Also adds the `github-actions` ecosystem for when CI workflows land.